### PR TITLE
RE-163 Add reusable CI/CD workflows and Dockerfile template

### DIFF
--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -1,0 +1,80 @@
+name: Reusable CD Workflow
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+      container-name:
+        required: true
+        type: string
+      container-port:
+        required: true
+        type: string
+      network-type:
+        required: true
+        type: string
+        description: 'public or private'
+    secrets:
+      EC2_SSH_KEY:
+        required: true
+      EC2_HOST:
+        required: true
+      EC2_USERNAME:
+        required: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: public.ecr.aws/e7w4k6e4
+  NETWORK_PUBLIC: reinput-network-public
+  NETWORK_PRIVATE: reinput-network-private
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/reinput-key.pem
+          chmod 600 ~/.ssh/reinput-key.pem
+          cat >>~/.ssh/config <<END
+          Host ec2
+            HostName ${{ secrets.EC2_HOST }}
+            User ${{ secrets.EC2_USERNAME }}
+            IdentityFile ~/.ssh/reinput-key.pem
+            StrictHostKeyChecking no
+          END
+
+      - name: Deploy to EC2
+        run: |
+          ssh ec2 '
+            aws ecr-public get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}
+
+            if [ "${{ inputs.network-type }}" = "public" ]; then
+              NETWORK_NAME="${{ env.NETWORK_PUBLIC }}"
+            else
+              NETWORK_NAME="${{ env.NETWORK_PRIVATE }}"
+            fi
+
+            if ! docker network ls | grep -q $NETWORK_NAME; then
+              docker network create $NETWORK_NAME
+            fi
+
+            if docker ps -a | grep -q ${{ inputs.container-name }}; then
+              docker stop ${{ inputs.container-name }}
+              docker rm ${{ inputs.container-name }}
+              docker rmi ${{ env.ECR_REGISTRY }}/${{ inputs.image-name }}:latest || true
+            fi
+
+            docker pull ${{ env.ECR_REGISTRY }}/${{ inputs.image-name }}:latest
+            docker run -d \
+              --name ${{ inputs.container-name }} \
+              --network $NETWORK_NAME \
+              -p ${{ inputs.container-port }}:${{ inputs.container-port }} \
+              ${{ env.ECR_REGISTRY }}/${{ inputs.image-name }}:latest
+            
+            docker ps | grep ${{ inputs.container-name }}
+          '

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,53 @@
+name: Reusable CI Workflow
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: public.ecr.aws/e7w4k6e4
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ inputs.image-name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # reinput-shared-workflows
 A centralized repository for reusable GitHub Actions workflows, designed to streamline CI/CD processes and standardize pipelines across projects.
+
+## Structure
+
+```
+reinput-shared-workflows/
+├── .github/
+│   └── workflows/
+│       ├── reusable-ci.yml
+│       └── reusable-cd.yml
+└── templates/
+    └── Dockerfile.gradle 
+```

--- a/templates/Dockerfile.gradle
+++ b/templates/Dockerfile.gradle
@@ -1,0 +1,22 @@
+# Use shared Dockerfile template
+
+# Build stage
+FROM gradle:8.5-jdk17 AS builder
+WORKDIR /app
+COPY . .
+RUN gradle build -x test
+
+# Run stage
+FROM amazoncorretto:17-alpine3.20
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE ${PORT}
+
+ENTRYPOINT ["java", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-XX:+ExitOnOutOfMemoryError", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", "app.jar" \
+]


### PR DESCRIPTION
- Introduced two reusable GitHub Actions workflows: `reusable-ci.yml` for building and pushing Docker images, and `reusable-cd.yml` for deploying to EC2.
- Updated README.md to include project structure and details about the workflows.
- Added a Dockerfile template for building Java applications using Gradle.

close [RE-163]

[RE-163]: https://reinput.atlassian.net/browse/RE-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ